### PR TITLE
Catch CompactionFailed exceptions in base-4.10+

### DIFF
--- a/UnexceptionalIO.hs
+++ b/UnexceptionalIO.hs
@@ -129,6 +129,9 @@ syncIO a = Ex.catches (fmap Right a) [
 #if MIN_VERSION_base(4,9,0)
 		Ex.Handler (\e -> Ex.throwIO (e :: Ex.TypeError)),
 #endif
+#if MIN_VERSION_base(4,10,0)
+		Ex.Handler (\e -> Ex.throwIO (e :: Ex.CompactionFailed)),
+#endif
 		Ex.Handler (return . Left)
 	]
 #else


### PR DESCRIPTION
`base-4.10` introduced a new [`CompactionFailed`](http://hackage.haskell.org/package/base-4.10.0.0/docs/Control-Exception.html#t:CompactionFailed) exception, so let's catch it here.