### PR TITLE
Rephrase docs for UIO and Unexceptional

### DIFF
--- a/UnexceptionalIO.hs
+++ b/UnexceptionalIO.hs
@@ -186,7 +186,7 @@ throwIO :: SomeNonPseudoException -> IO a
 throwIO = ioError
 #endif
 
--- | IO without any 'PseudoException'
+-- | Like IO, but throws only 'PseudoException'
 newtype UIO a = UIO (IO a)
 
 instance Functor UIO where
@@ -205,7 +205,7 @@ instance Monad UIO where
 instance MonadFix UIO where
 	mfix f = UIO (mfix $ run . f)
 
--- | Polymorphic base without any 'PseudoException'
+-- | Monads in which 'UIO' computations may be embedded
 class (Monad m) => Unexceptional m where
 	lift :: UIO a -> m a
 


### PR DESCRIPTION
Current documentation says UIO is "like IO without any PseudoException", which I believe is confusing. Surely the point UIO is to throw *nothing but* PseudoExceptions. This commit rewrites docs with a hopefully more clear description (feedback welcome).